### PR TITLE
Add tests for translated key order and some cases of duplicate keys.

### DIFF
--- a/tests/Language/AbstractTranslationTestCase.php
+++ b/tests/Language/AbstractTranslationTestCase.php
@@ -305,7 +305,7 @@ abstract class AbstractTranslationTestCase extends TestCase
 
 					if ($val2 && $val2 !== $val1)
 					{
-						$diffs[] = '"' . $file . '" ' . 'index "' . $key1 . '" is "' . $val2 . '", should be "' . $val1 . '".';
+						$diffs[] = "{$file}:\n  - {$key1} => '{$val1}'\n  + {$key1} => '{$val2}'";
 						break;
 					}
 				}
@@ -313,9 +313,9 @@ abstract class AbstractTranslationTestCase extends TestCase
 		}
 
 		self::assertEmpty($diffs, sprintf(
-			'Failed asserting that the translated language keys in "%s" locale are ordered correctly. %s',
+			"Failed asserting that the translated language keys in \"%s\" locale are ordered correctly.\n%s",
 			$locale,
-			implode(' ', $diffs)
+			implode("\n", $diffs)
 		));
 	}
 

--- a/tests/Language/AbstractTranslationTestCase.php
+++ b/tests/Language/AbstractTranslationTestCase.php
@@ -298,12 +298,14 @@ abstract class AbstractTranslationTestCase extends TestCase
 			// This is handled by the other tests
 			if(count($original) === count($translated)){
 				// Check if the order is correct
-				$diff = $this->arrayDiffOrder($original, $translated);
-				
-				// Store result if failed
-				if($diff !== '')
+				foreach($original as $key1 => $val1)
 				{
-					$diffs[] = '"'.$file.'" '.$diff.'.';
+					$val2 = $translated[$key1] ?? null;
+					if($val2 && $val2 !== $val1)
+					{
+						$diffs[] = '"'.$file.'" '.'index "'.$key1.'" is "'.$val2.'", should be "'.$val1.'".';
+						break;
+					}
 				}
 			}
 		}
@@ -419,28 +421,5 @@ abstract class AbstractTranslationTestCase extends TestCase
 		}
 
 		return $sets;
-	}
-
-	/**
-	 * Checks if the order of array keys in two arrays is equal.
-	 *
-	 * @param array<string, string> $array1
-	 * @param array<string, string> $array2
-	 *
-	 * 
-	 * @return string
-	 */
-	private function arrayDiffOrder(array $array1, array $array2): string
-	{
-		foreach($array1 as $key1 => $val1)
-		{
-			$val2 = $array2[$key1] ?? null;
-			if($val2 && $val2 !== $val1)
-			{
-				return 'index "'.$key1.'" is "'.$val2.'", should be "'.$val1.'"';
-			}
-		}
-
-		return '';
 	}
 }

--- a/tests/Language/AbstractTranslationTestCase.php
+++ b/tests/Language/AbstractTranslationTestCase.php
@@ -296,14 +296,16 @@ abstract class AbstractTranslationTestCase extends TestCase
 
 			// No need to check the order if the number of keys is already different
 			// This is handled by the other tests
-			if(count($original) === count($translated)){
+			if (count($original) === count($translated))
+			{
 				// Check if the order is correct
-				foreach($original as $key1 => $val1)
+				foreach ($original as $key1 => $val1)
 				{
 					$val2 = $translated[$key1] ?? null;
-					if($val2 && $val2 !== $val1)
+
+					if ($val2 && $val2 !== $val1)
 					{
-						$diffs[] = '"'.$file.'" '.'index "'.$key1.'" is "'.$val2.'", should be "'.$val1.'".';
+						$diffs[] = '"' . $file . '" ' . 'index "' . $key1 . '" is "' . $val2 . '", should be "' . $val1 . '".';
 						break;
 					}
 				}
@@ -316,7 +318,6 @@ abstract class AbstractTranslationTestCase extends TestCase
 			implode(' ', $diffs)
 		));
 	}
-
 
 	final public function localesProvider(): iterable
 	{


### PR DESCRIPTION
This adds a test method to check whether the order of the translated keys is the same as in the main repo.
At the same time, this also protects against duplicate key definitions in translated file, but not all possible cases.

Example that will trigger an error:

    'key1' => 'val1',
    'key2' => 'val2',
    'key1' => 'val3',

Example that will not trigger an error:

    'key1' => 'val1',
    'key1' => 'val3',
    'key2' => 'val2',

Example output for current `it` locale:

    Failed asserting that the translated language keys in "it" locale have the same order as the original keys in the main repository. This can also be caused by duplicate key definitions. First mismatch per file:
    Migrations:
      - 26 => 'migSeeder'
      + 26 => 'on'  
    Validation:
     - 26 => 'matches'
     + 26 => 'string'
    Failed asserting that an array is empty.

I would think the other cases of duplicate keys are pretty obvious to see when editing a translation file and should not occur too often. If we wanted to check them too, we would need to `file_get_contents` the language files and compare the line on which each key is defined (or the total number of lines in the file). This would of course also require us to have consistent comments and blank lines in the files (which is not a bad thing in my opinion).