### PR TITLE
Update Cast and Core for ja

### DIFF
--- a/Language/ja/Cast.php
+++ b/Language/ja/Cast.php
@@ -11,13 +11,13 @@
 
 // Cast language settings
 return [
+	'invalidTimestamp'       => '型キャスト "timestamp" には正しいタイムスタンプを指定してください。', //'Type casting "timestamp" expects a correct timestamp.',
+	'jsonErrorCtrlChar'      => '予期しない制御文字が見つかりました。', //'Unexpected control character found.',
 	'jsonErrorDepth'         => '最大スタックの深さを超えました。', //'Maximum stack depth exceeded.',
 	'jsonErrorStateMismatch' => 'アンダーフローまたはモードの不一致です。', //'Underflow or the modes mismatch.',
-	'jsonErrorCtrlChar'      => '予期しない制御文字が見つかりました。', //'Unexpected control character found.',
 	'jsonErrorSyntax'        => '構文エラー、不正な JSON。', //'Syntax error, malformed JSON.',
-	'jsonErrorUtf8'          => '不正な UTF-8 文字があり、誤ってエンコードされた可能性があります。', //'Malformed UTF-8 characters, possibly incorrectly encoded.',
 	'jsonErrorUnknown'       => '未知のエラー。', //'Unknown error.',
 	'abstractCastMissing'    => '{0} クラスは CodeIgniter\EntityCast\AbstractCast を継承しなければいけません。', //'The {0} class must inherit the CodeIgniter\EntityCast\AbstractCast class.',
 	'wrongCastMethod'        => 'キャストに使用できるメソッドは "get" と "set" です。', //'Allowed methods for cast is "get" and "set".',
-	'invalidTimestamp'       => '型キャスト "timestamp" には正しいタイムスタンプを指定してください。', //'Type casting "timestamp" expects a correct timestamp.',
+	'jsonErrorUtf8'          => '不正な UTF-8 文字があり、誤ってエンコードされた可能性があります。', //'Malformed UTF-8 characters, possibly incorrectly encoded.',
 ];

--- a/Language/ja/Cast.php
+++ b/Language/ja/Cast.php
@@ -11,13 +11,13 @@
 
 // Cast language settings
 return [
+	'baseCastMissing'        => 'クラス "{0}" は "CodeIgniter\Entity\Cast\BaseCast" を継承しなければいけません。', //'The "{0}" class must inherit the "CodeIgniter\Entity\Cast\BaseCast" class.',
+	'invalidCastMethod'      => 'メソッド "{0}" は無効なキャストメソッドです。有効なメソッド: ["get", "set"]', //'The "{0}" is invalid cast method, valid methods are: ["get", "set"].',
 	'invalidTimestamp'       => '型キャスト "timestamp" には正しいタイムスタンプを指定してください。', //'Type casting "timestamp" expects a correct timestamp.',
 	'jsonErrorCtrlChar'      => '予期しない制御文字が見つかりました。', //'Unexpected control character found.',
 	'jsonErrorDepth'         => '最大スタックの深さを超えました。', //'Maximum stack depth exceeded.',
 	'jsonErrorStateMismatch' => 'アンダーフローまたはモードの不一致です。', //'Underflow or the modes mismatch.',
 	'jsonErrorSyntax'        => '構文エラー、不正な JSON。', //'Syntax error, malformed JSON.',
 	'jsonErrorUnknown'       => '未知のエラー。', //'Unknown error.',
-	'abstractCastMissing'    => '{0} クラスは CodeIgniter\EntityCast\AbstractCast を継承しなければいけません。', //'The {0} class must inherit the CodeIgniter\EntityCast\AbstractCast class.',
-	'wrongCastMethod'        => 'キャストに使用できるメソッドは "get" と "set" です。', //'Allowed methods for cast is "get" and "set".',
 	'jsonErrorUtf8'          => '不正な UTF-8 文字があり、誤ってエンコードされた可能性があります。', //'Malformed UTF-8 characters, possibly incorrectly encoded.',
 ];

--- a/Language/ja/Core.php
+++ b/Language/ja/Core.php
@@ -14,6 +14,7 @@ return [
 	'copyError'                    => 'ファイル({0})を置換しようとしたときにエラーが発生しました。ファイルまたはディレクトリが書き込み可能であることを確認してください。', //An error was encountered while attempting to replace the file({0}). Please make sure your file directory is writable.
 	'enabledZlibOutputCompression' => 'zlib.output_compression が on に設定されているため、出力バッファが正常に機能しません。', //Your zlib.output_compression ini directive is turned on. This will not work well with output buffers.
 	'invalidFile'                  => '無効なファイル: {0}', //Invalid file: {0}
+	'invalidPhpVersion'            => 'CodeIgniter を実行するには PHP {0} 以上が必要です。現在のバージョン: {1}', //'Your PHP version must be {0} or higher to run CodeIgniter. Current version: {1}',
 	'missingExtension'             => '{0} 拡張モジュールはロードされませんでした。', //{0} extension is not loaded.
 	'noHandlers'                   => '{0} は少なくとも1つのハンドラを指定する必要があります。', //{0} must provide at least one Handler.
 ];


### PR DESCRIPTION
Update:
- Cast.php
- Core.php

```sh-session
$ vendor/bin/phpunit --filter JapaneseTranslationTest
PHPUnit 9.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.21
Configuration: /Users/kenji/work/codeigniter/codeigniter4-translations/phpunit.xml.dist

.......                                                             7 / 7 (100%)

Time: 00:00.098, Memory: 22.00 MB

OK (7 tests, 7 assertions)
```
