### PR TITLE
Add header comment to scripts

### DIFF
--- a/.github/scripts/continuous-integration
+++ b/.github/scripts/continuous-integration
@@ -1,6 +1,15 @@
 #!/usr/bin/env php
 <?php
 
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
 require __DIR__ . '/../../vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php';
 
 use CodeIgniter\CLI\CLI;

--- a/bin/test
+++ b/bin/test
@@ -1,6 +1,15 @@
 #!/usr/bin/env php
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
 require __DIR__ . '/../vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php';
 
 use CodeIgniter\CLI\CLI;


### PR DESCRIPTION
From latest php-cs-fixer v3.6, scripts also get header comments if `header_comment` is on.