### PR TITLE
chore: add script to add en lang strings as comments

### DIFF
--- a/bin/update-en-comments
+++ b/bin/update-en-comments
@@ -25,6 +25,7 @@ if ($argc !== 2) {
 $locale = $argv[1];
 
 $langDir = __DIR__ . '/../Language/' . $locale;
+
 if (! is_dir($langDir)) {
     CLI::error('No such directory: "' . $langDir . '"');
 
@@ -32,6 +33,7 @@ if (! is_dir($langDir)) {
 }
 
 $enDir = VENDORPATH . 'codeigniter4/CodeIgniter4/system/Language/en';
+
 if (! is_dir($enDir)) {
     CLI::error('No "Language/en" directory. Please run "composer update".');
 

--- a/bin/update-en-comments
+++ b/bin/update-en-comments
@@ -55,7 +55,9 @@ $enFiles = get_filenames(
 );
 
 foreach ($enFiles as $enFile) {
-    $langFile = $langDir . '/' . substr($enFile, strlen($enDir) + 1);
+    $temp     = $langDir . '/' . substr($enFile, strlen($enDir) + 1);
+    $langFile = realpath($temp) ?: $temp;
+
     if (! is_file($langFile)) {
         CLI::error('No such file: "' . $langFile . '"');
 
@@ -94,7 +96,7 @@ foreach ($enFiles as $enFile) {
 
             foreach ($items as $item) {
                 if (array_key_first($item) === $key) {
-                    $newLangFile .= $indent . "'" . $key . "'" . $arrow . $value . ", // " . $item[$key] . "\n";
+                    $newLangFile .= $indent . "'" . $key . "'" . $arrow . $value . ', // ' . $item[$key] . "\n";
                     unset($item[$key]);
                 }
             }

--- a/bin/update-en-comments
+++ b/bin/update-en-comments
@@ -1,0 +1,104 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+require __DIR__ . '/../vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php';
+
+use CodeIgniter\CLI\CLI;
+
+helper('filesystem');
+
+if ($argc !== 2) {
+    CLI::error('Please specify a locale.');
+
+    exit(1);
+}
+
+$locale = $argv[1];
+
+$langDir = __DIR__ . '/../Language/' . $locale;
+if (! is_dir($langDir)) {
+    CLI::error('No such directory: "' . $langDir . '"');
+
+    exit(1);
+}
+
+$enDir = VENDORPATH . 'codeigniter4/CodeIgniter4/system/Language/en';
+if (! is_dir($enDir)) {
+    CLI::error('No "Language/en" directory. Please run "composer update".');
+
+    exit(1);
+}
+
+$files = get_filenames(
+    $langDir,
+    true,
+    false,
+    false
+);
+
+$enFiles = get_filenames(
+    $enDir,
+    true,
+    false,
+    false
+);
+
+foreach ($enFiles as $enFile) {
+    $langFile = $langDir . '/' . substr($enFile, strlen($enDir) + 1);
+    if (! is_file($langFile)) {
+        CLI::error('No such file: "' . $langFile . '"');
+
+        continue;
+    }
+
+    $enFileLines = file($enFile);
+
+    $items = [];
+
+    $pattern = '/(.*)\'([a-zA-Z0-9_]+?)\'(\s*=>\s*)([\'"].+[\'"]),/u';
+
+    foreach ($enFileLines as $line) {
+        if (preg_match($pattern, $line, $matches)) {
+            $items[] = [$matches[2] => $matches[4]];
+        }
+    }
+
+    $langFileLines = file($langFile);
+
+    $newLangFile = '';
+
+    foreach ($langFileLines as $line) {
+        // Remove en value comment.
+        if (preg_match('!(.*,)(\s*//.*)$!u', $line, $matches)) {
+            $line = $matches[1] . "\n";
+        }
+
+        if (preg_match($pattern, $line, $matches) === 0) {
+            $newLangFile .= $line;
+        } else {
+            $indent = $matches[1];
+            $key    = $matches[2];
+            $arrow  = $matches[3];
+            $value  = $matches[4];
+
+            foreach ($items as $item) {
+                if (array_key_first($item) === $key) {
+                    $newLangFile .= $indent . "'" . $key . "'" . $arrow . $value . ", // " . $item[$key] . "\n";
+                    unset($item[$key]);
+                }
+            }
+        }
+    }
+
+    file_put_contents($langFile, $newLangFile);
+    CLI::write('Updated: ' . $langFile);
+}


### PR DESCRIPTION
Add a script to add english strings as comments. It is used in #329.

**Note:** When you run this script, all comments after the translation strings like the following will be removed.
```php
'noDriverRequested'    => 'ドライバは不要です。', // ダジャレは翻訳しません
```

**How to Use**
```console
$ composer update
$ bin/update-en-comments bs
```
```diff
$ git diff Language/bs/Test.php
diff --git a/Language/bs/Test.php b/Language/bs/Test.php
index 91efe6d..50f3591 100644
--- a/Language/bs/Test.php
+++ b/Language/bs/Test.php
@@ -11,5 +11,5 @@
 
 // Testing language settings
 return [
-    'invalidMockClass' => '{0} nije validna Mock klasa',
+    'invalidMockClass' => '{0} nije validna Mock klasa', // '{0} is not a valid Mock class'
 ];
```
