### PR TITLE
fix: `update-en-comments` does not work when having duplicate keys

### DIFF
--- a/bin/update-en-comments
+++ b/bin/update-en-comments
@@ -80,6 +80,8 @@ foreach ($enFiles as $enFile) {
 
     $newLangFile = '';
 
+    $itemNo = 0;
+
     foreach ($langFileLines as $line) {
         // Remove en value comment.
         if (preg_match('!(.*,)(\s*//.*)$!u', $line, $matches)) {
@@ -94,12 +96,9 @@ foreach ($enFiles as $enFile) {
             $arrow  = $matches[3];
             $value  = $matches[4];
 
-            foreach ($items as $item) {
-                if (array_key_first($item) === $key) {
-                    $newLangFile .= $indent . "'" . $key . "'" . $arrow . $value . ', // ' . $item[$key] . "\n";
-                    unset($item[$key]);
-                }
-            }
+            $newLangFile .= $indent . "'" . $key . "'" . $arrow . $value
+                . ', // ' . $items[$itemNo][array_key_first($items[$itemNo])] . "\n";
+            $itemNo++;
         }
     }
 


### PR DESCRIPTION
Before:
```diff
--- a/Language/ja/CLI.php
+++ b/Language/ja/CLI.php
@@ -18,6 +18,7 @@ return [
         'cancelOperation' => '操作はキャンセルされました。', // 'Operation has been cancelled.'
         'className'       => [
             'cell'       => 'セルのクラス名', // 'Cell class name'
+            'cell'       => 'セルのクラス名', // 'Cell view name'
             'command'    => 'コマンドクラス名', // 'Command class name'
             'config'     => '設定クラス名', // 'Config class name'
             'controller' => 'コントローラクラス名', // 'Controller class name'
@@ -40,6 +41,7 @@ return [
         'tableName'        => 'テーブル名', // 'Table name'
         'usingCINamespace' => '警告: 名前空間 "CodeIgniter" を使用するとsystemディレクトリにファイルが生成されます。', // 'Warning: Using the "CodeIgniter" namespace will generate the file in the system directory.'
         'viewName'         => [
+            'cell' => 'セルのビュー名', // 'Cell class name'
             'cell' => 'セルのビュー名', // 'Cell view name'
         ],
     ],
```