### PR TITLE
[de] Convert windows-1252 files to UTF-8

### DIFF
--- a/Language/de/Files.php
+++ b/Language/de/Files.php
@@ -13,6 +13,6 @@
 return [
     'fileNotFound'      => 'Datei nicht gefunden: {0}',
     'cannotMove'        => 'Datei konnte nicht von {0} nach {1} verschoben werden ({2}).',
-    'expectedDirectory' => '{0} erwartet einen gültigen Ordner.',
-    'expectedFile'      => '{0} erwartet eine gültige Datei.',
+    'expectedDirectory' => '{0} erwartet einen gÃ¼ltigen Ordner.',
+    'expectedFile'      => '{0} erwartet eine gÃ¼ltige Datei.',
 ];

--- a/Language/de/Publisher.php
+++ b/Language/de/Publisher.php
@@ -12,11 +12,11 @@
 // Publisher language settings
 return [
     'collision'             => 'Publisher hat ein unerwartetes {0} beim Kopieren von {1} nach {2} festgestellt.',
-    'destinationNotAllowed' => 'Das Ziel befindet sich nicht in der Liste der zulässigen Publisher-Verzeichnisse: {0}',
-    'fileNotAllowed'        => '{0} erfüllt die folgende Einschränkung für {1} nicht: {2}',
+    'destinationNotAllowed' => 'Das Ziel befindet sich nicht in der Liste der zulÃ¤ssigen Publisher-Verzeichnisse: {0}',
+    'fileNotAllowed'        => '{0} erfÃ¼llt die folgende EinschrÃ¤nkung fÃ¼r {1} nicht: {2}',
 
     // Publish Command
-    'publishMissing' => 'Es konnten keine Publisher-Klassen in {0} in allen Namensräumen detektiert werden.',
+    'publishMissing' => 'Es konnten keine Publisher-Klassen in {0} in allen NamensrÃ¤umen detektiert werden.',
     'publishSuccess' => '{0} hat {1} Datei(en) nach {2} publiziert.',
     'publishFailure' => '{0} konnte nicht nach {1} publiziert werden!',
 ];

--- a/Language/de/Test.php
+++ b/Language/de/Test.php
@@ -11,5 +11,5 @@
 
 // Testing language settings
 return [
-    'invalidMockClass' => '{0} ist keine gültige Mock-Klasse',
+    'invalidMockClass' => '{0} ist keine gÃ¼ltige Mock-Klasse',
 ];


### PR DESCRIPTION
**Description**
Some DE files are encoded in "windows-1252" charset instead of UTF-8.
I think it's a mistake and after a quick research I didn't find a closed issue about this or any logic why these files are in a different encoding.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
