### PR TITLE
[sv-SE] Update sv-SE, added Language.PHP and missing HTTP strings

### DIFF
--- a/Language/sv-SE/HTTP.php
+++ b/Language/sv-SE/HTTP.php
@@ -18,6 +18,8 @@ return [
 
     // IncomingRequest
     'invalidNegotiationType' => '"{0}" är inte en giltig negotiation typ. Den måste vara en av: media, charset, encoding, language.',
+    'invalidJSON'            => 'Kunde inte tolka JSON strängen. Fel: {0}',
+    'unsupportedJSONFormat'  => 'Det givna JSON formatet stödjs inte.',
 
     // Message
     'invalidHTTPProtocol' => 'Felaktigt HTTP Protocol Version. Måste bli en av: {0}',

--- a/Language/sv-SE/Language.php
+++ b/Language/sv-SE/Language.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+return [
+    'invalidMessageFormat' => 'Ogiltigt meddelandeformat: "{0}", argument: "{1}"',
+];


### PR DESCRIPTION
**Description**
Supersedes #424

Another try at the PR from yesterday... Updated sv_SE language with Language.php and missing JSON related strings in HTTP.php

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
