### PR TITLE
refactor: update to PHP 8.1 and PHPUnit 10.5 || 11.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,16 +5,16 @@
     "homepage": "https://codeigniter.com",
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-intl": "*"
     },
     "require-dev": {
         "ext-tokenizer": "*",
-        "codeigniter/coding-standard": "^1.1",
+        "codeigniter/coding-standard": "^1.7",
         "codeigniter4/codeigniter4": "4.x-dev",
-        "friendsofphp/php-cs-fixer": "^3.1",
-        "nexusphp/cs-config": "^3.3",
-        "phpunit/phpunit": "^9.5"
+        "friendsofphp/php-cs-fixer": "^3.53",
+        "nexusphp/cs-config": "^3.22",
+        "phpunit/phpunit": "^10.5 || ^11.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,14 @@
 {
     "name": "codeigniter4/translations",
-    "type": "project",
     "description": "Translations for CodeIgniter v4 web framework",
-    "homepage": "https://codeigniter.com",
     "license": "MIT",
+    "type": "project",
+    "homepage": "https://codeigniter.com",
+    "support": {
+        "forum": "http://forum.codeigniter.com/",
+        "source": "https://github.com/codeigniter4/translations",
+        "slack": "https://codeigniterchat.slack.com"
+    },
     "require": {
         "php": "^8.1",
         "ext-intl": "*"
@@ -16,16 +21,13 @@
         "nexusphp/cs-config": "^3.22",
         "phpunit/phpunit": "^10.5 || ^11.0"
     },
-    "config": {
-        "optimize-autoloader": true,
-        "preferred-install": "dist",
-        "sort-packages": true
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-develop": "4.x-dev"
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/codeigniter4/CodeIgniter4",
+            "canonical": true
         }
-    },
+    ],
     "autoload": {
         "psr-4": {
             "Translations\\": ""
@@ -37,16 +39,14 @@
             "Translations\\Tests\\AutoReview\\": "tests/AutoReview"
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/codeigniter4/CodeIgniter4",
-            "canonical": true
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "4.x-dev"
         }
-    ],
-    "support": {
-        "forum": "http://forum.codeigniter.com/",
-        "source": "https://github.com/codeigniter4/translations",
-        "slack": "https://codeigniterchat.slack.com"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.1/phpunit.xsd"
          bootstrap="vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php"
-         cacheResultFile=".phpunit.cache/test-results"
          backupGlobals="false"
          colors="true"
          columns="max"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         verbose="true">
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Automatic Review Test Suite">
             <directory suffix="Test.php">tests/AutoReview</directory>
@@ -23,11 +19,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage cacheDirectory=".phpunit.cache/code-coverage" processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">Language</directory>
         </include>
-    </coverage>
+    </source>
 
     <php>
         <env name="app.baseURL" value="http://example.com/"/>

--- a/tests/AutoReview/LicenseTest.php
+++ b/tests/AutoReview/LicenseTest.php
@@ -11,15 +11,15 @@
 
 namespace Translations\Tests\AutoReview;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
- *
- * @coversNothing
- *
- * @group license-review
  */
+#[CoversNothing]
+#[Group('license-review')]
 final class LicenseTest extends TestCase
 {
     public function testLicenseCopyrightYearIsUpdated(): void

--- a/tests/AutoReview/TranslationsCodeTest.php
+++ b/tests/AutoReview/TranslationsCodeTest.php
@@ -11,6 +11,8 @@
 
 namespace Translations\Tests\AutoReview;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Translations\Tests\AbstractTranslationTestCase;
 
@@ -18,11 +20,9 @@ use Translations\Tests\AbstractTranslationTestCase;
  * This test case eases away the boring review of tiny details in one's pull request.
  *
  * @internal
- *
- * @coversNothing
- *
- * @group auto-review
  */
+#[CoversNothing]
+#[Group('auto-review')]
 final class TranslationsCodeTest extends TestCase
 {
     public function testLocalesArrayAreArrangedByLocaleCode(): void

--- a/tests/AutoReview/TranslationsCodeTest.php
+++ b/tests/AutoReview/TranslationsCodeTest.php
@@ -36,12 +36,9 @@ final class TranslationsCodeTest extends TestCase
 
     public function testAllTranslatedLocalesAreIncludedInTheReadMe(): void
     {
-        $locales = (new class () extends AbstractTranslationTestCase {})->translationKeys();
-        $locales = array_keys($locales);
-
         $readme = $this->getContentsOrFail(__DIR__ . '/../../README.md');
 
-        foreach ($locales as $locale) {
+        foreach ($this->locales() as $locale) {
             $this->assertSame(1, preg_match(sprintf('/\| %s \s+\|/', $locale), $readme), sprintf(
                 'The locale "%s" is not found in the README.md file. Please add it.',
                 $locale
@@ -51,16 +48,27 @@ final class TranslationsCodeTest extends TestCase
 
     public function testAllTranslatedLocalesAreNotIncludedInMissing(): void
     {
-        $locales = (new class () extends AbstractTranslationTestCase {})->translationKeys();
-        $locales = array_keys($locales);
-
         $missing = $this->getContentsOrFail(__DIR__ . '/../../MISSING.md');
 
-        foreach ($locales as $locale) {
+        foreach ($this->locales() as $locale) {
             $this->assertSame(0, preg_match(sprintf('/\| %s \s+\|/', $locale), $missing), sprintf(
                 'The locale "%s" is already translated and should no longer be found in MISSING.md file.',
                 $locale
             ));
+        }
+    }
+
+    /**
+     * Get all the ISO 639-1 and 639-2 locale codes.
+     *
+     * @return iterable<string>
+     */
+    private function locales(): iterable
+    {
+        helper('filesystem');
+
+        foreach (directory_map(getcwd() . '/Language', 1) as $dir) {
+            yield trim($dir, '\\/');
         }
     }
 

--- a/tests/Language/AbstractTranslationTestCase.php
+++ b/tests/Language/AbstractTranslationTestCase.php
@@ -12,6 +12,7 @@
 namespace Translations\Tests;
 
 use CodeIgniter\CLI\CLI;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -94,9 +95,8 @@ abstract class AbstractTranslationTestCase extends TestCase
     /**
      * This tests that all language files configured in the main CI4 repository
      * have a corresponding language file in the current locale.
-     *
-     * @dataProvider localesProvider
      */
+    #[DataProvider('localesProvider')]
     final public function testAllConfiguredLanguageFilesAreTranslated(string $locale): void
     {
         $filesNotTranslated = array_diff(
@@ -119,9 +119,8 @@ abstract class AbstractTranslationTestCase extends TestCase
     /**
      * This tests that all translated language files in the current locale have a
      * corresponding language file in the main CI4 repository.
-     *
-     * @dataProvider localesProvider
      */
+    #[DataProvider('localesProvider')]
     final public function testAllTranslatedLanguageFilesAreConfigured(string $locale): void
     {
         $filesNotConfigured = array_diff(
@@ -144,9 +143,8 @@ abstract class AbstractTranslationTestCase extends TestCase
     /**
      * This tests that all language keys defined by a language file in the main CI4
      * repository have corresponding keys in the current locale.
-     *
-     * @dataProvider localesProvider
      */
+    #[DataProvider('localesProvider')]
     final public function testAllConfiguredLanguageKeysAreIncluded(string $locale): void
     {
         $keysNotIncluded = [];
@@ -177,9 +175,8 @@ abstract class AbstractTranslationTestCase extends TestCase
     /**
      * This tests that all included language keys in a language file for the current
      * locale have corresponding keys in the main CI4 repository.
-     *
-     * @dataProvider localesProvider
      */
+    #[DataProvider('localesProvider')]
     final public function testAllIncludedLanguageKeysAreConfigured(string $locale): void
     {
         $keysNotConfigured = [];
@@ -211,9 +208,8 @@ abstract class AbstractTranslationTestCase extends TestCase
      * This tests that all included language keys in a language file for the current
      * locale that have corresponding keys in the main CI4 repository are really translated
      * and do not only copy the main repository's value.
-     *
-     * @dataProvider localesProvider
      */
+    #[DataProvider('localesProvider')]
     final public function testAllIncludedLanguageKeysAreTranslated(string $locale): void
     {
         // These keys are usually not translated because they contain either
@@ -263,9 +259,8 @@ abstract class AbstractTranslationTestCase extends TestCase
     /**
      * This tests that the order of all language keys defined by a translation language file
      * resembles the order in the main CI4 repository.
-     *
-     * @dataProvider localesProvider
      */
+    #[DataProvider('localesProvider')]
     final public function testAllConfiguredLanguageKeysAreInOrder(string $locale): void
     {
         $diffs = [];
@@ -317,9 +312,7 @@ abstract class AbstractTranslationTestCase extends TestCase
         return [$locale => [$locale]];
     }
 
-    /**
-     * @dataProvider localesProvider
-     */
+    #[DataProvider('localesProvider')]
     final public function testLocaleHasCorrespondingTestCaseFile(string $locale): void
     {
         $class = array_flip(self::$locales)[$locale];


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Updates minimum PHP version to ^8.1 to align with CodeIgniter v4.5.0 and also updates PHPUnit to 10.5 || 11.0

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
