### PR TITLE
chore: fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Translations for CodeIgniter 4 System Messages
 
-![build](https://github.com/codeigniter4/translations/workflows/build/badge.svg?branch=develop)
-![code style](https://github.com/codeigniter4/translations/workflows/code%20style/badge.svg?branch=develop)
+[![build](https://github.com/codeigniter4/translations/actions/workflows/build.yml/badge.svg)](https://github.com/codeigniter4/translations/actions/workflows/build.yml)
+[![code style](https://github.com/codeigniter4/translations/actions/workflows/code-style.yml/badge.svg)](https://github.com/codeigniter4/translations/actions/workflows/code-style.yml)
 [![Latest Stable Version](https://poser.pugx.org/codeigniter4/translations/v)](//packagist.org/packages/codeigniter4/translations)
 [![Total Downloads](https://poser.pugx.org/codeigniter4/translations/downloads)](//packagist.org/packages/codeigniter4/translations)
 [![License](https://poser.pugx.org/codeigniter4/translations/license)](//packagist.org/packages/codeigniter4/translations)


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
I'm not sure what happened to the badges:
<img width="281" alt="Screenshot 2025-01-29 at 20 32 02" src="https://github.com/user-attachments/assets/0c64173d-914f-4a33-a4e1-5a662f0d4ed3" />

So, extracted the latest badges from the Actions panel.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
