### PR TITLE
fix: test translation

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -33,7 +33,7 @@ CLI::write('Fixing coding style...', 'black', 'green');
 passthru("{$phpCsFixer} fix --verbose --diff");
 CLI::write();
 
-$testCase = new class () extends AbstractTranslationTestCase {
+$testCase = new class ('test_helper') extends AbstractTranslationTestCase {
     public function getTestCaseClassname(string $locale): string
     {
         $classname = array_flip(self::$locales)[$locale] ?? null;


### PR DESCRIPTION
**Description**
When running:

```cli
./bin/test pl
```
I get an error:

```cli
{
    "title": "ArgumentCountError",
    "type": "ArgumentCountError",
    "code": 500,
    "message": "Too few arguments to function PHPUnit\\Framework\\TestCase::__construct(), 0 passed in /Users/michalsn/Sites/ci4_translations/bin/test on line 36 and exactly 1 expected",
    "file": "/Users/michalsn/Sites/ci4_translations/vendor/phpunit/phpunit/src/Framework/TestCase.php",
    "line": 239,
    "trace": [
        {
            "file": "/Users/michalsn/Sites/ci4_translations/bin/test",
            "line": 36,
            "function": "__construct",
            "class": "PHPUnit\\Framework\\TestCase",
            "type": "->",
            "args": []
        }
    ]
}
```

When we create an anonymous class that extends `AbstractTranslationTestCase`, that class inherits from PHPUnit's `TestCase` through the inheritance chain. The `TestCase` constructor expects a test name parameter to be used to identify the test case, and our code fails to provide this required argument.

This PR fixes that problem.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
