### PR TITLE
[pt-BR] Update 100% pt-BR translations

### DIFF
--- a/Language/pt-BR/Api.php
+++ b/Language/pt-BR/Api.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+// API language settings
+return [
+    'invalidFields'       => 'O campo solicitado é inválido: {0}',
+    'invalidIncludes'     => 'O recurso incluído (include) solicitado é inválido: {0}',
+    'missingInclude'      => 'Método de inclusão (include) não encontrado para: {0}',
+    'transformerNotFound' => 'A classe Transformer \'{0}\' não foi encontrada.',
+    'invalidTransformer'  => 'A classe Transformer \'{0}\' deve implementar a interface TransformerInterface.',
+];

--- a/Language/pt-BR/CLI.php
+++ b/Language/pt-BR/CLI.php
@@ -17,18 +17,19 @@ return [
     'generator'          => [
         'cancelOperation' => 'Operação foi cancelada.', // 'Operation has been cancelled.',
         'className'       => [
-            'cell'       => 'Nome da classe Cell', // 'Cell class name',
-            'command'    => 'Nome da classe Command', // 'Command class name',
-            'config'     => 'Nome da classe Config', // 'Config class name',
-            'controller' => 'Nome da classe Controller', // 'Controller class name',
-            'default'    => 'Nome da classe', // 'Class name',
-            'entity'     => 'Nome da classe Entity', // 'Entity class name',
-            'filter'     => 'Nome da classe Filter', // 'Filter class name',
-            'migration'  => 'Nome da classe Migration', // 'Migration class name',
-            'model'      => 'Nome da classe Model', // 'Model class name',
-            'seeder'     => 'Nome da classe Seeder', // 'Seeder class name',
-            'test'       => 'Nome da classe Test', // 'Test class name',
-            'validation' => 'Nome da classe Validation',  // 'Validation class name',
+            'cell'        => 'Nome da classe Cell', // 'Cell class name',
+            'command'     => 'Nome da classe Command', // 'Command class name',
+            'config'      => 'Nome da classe Config', // 'Config class name',
+            'controller'  => 'Nome da classe Controller', // 'Controller class name',
+            'default'     => 'Nome da classe', // 'Class name',
+            'entity'      => 'Nome da classe Entity', // 'Entity class name',
+            'filter'      => 'Nome da classe Filter', // 'Filter class name',
+            'migration'   => 'Nome da classe Migration', // 'Migration class name',
+            'model'       => 'Nome da classe Model', // 'Model class name',
+            'seeder'      => 'Nome da classe Seeder', // 'Seeder class name',
+            'test'        => 'Nome da classe Test', // 'Test class name',
+            'transformer' => 'Nome da classe Transformer', // 'Transformer class name',
+            'validation'  => 'Nome da classe Validation', // 'Validation class name',
         ],
         'commandType'      => 'Tipo de comando', // 'Command type',
         'databaseGroup'    => 'Grupo do banco de dados', // 'Database group',
@@ -50,4 +51,9 @@ return [
     'helpUsage'           => 'Uso:', // 'Usage:',
     'invalidColor'        => 'Cor inválida "{0}": "{1}".', // Invalid "{0}" color: "{1}".',
     'namespaceNotDefined' => 'Namespace "{0}" não está definido.', // 'Namespace "{0}" is not defined.',
+    'signals'             => [
+        'noPcntlExtension' => 'Extensão PCNTL não disponível. O manuseio de sinais foi desabilitado.', // PCNTL extension not available. Signal handling disabled.
+        'noPosixExtension' => 'O manuseio de SIGTSTP/SIGCONT requer a extensão POSIX. Esses sinais serão removidos do registro.', // SIGTSTP/SIGCONT handling requires POSIX extension. These signals will be removed from registration.
+        'failedSignal'     => 'Falha ao registrar manipulador para o sinal: "{0}".', // Failed to register handler for signal: "{0}".
+    ],
 ];

--- a/Language/pt-BR/Cast.php
+++ b/Language/pt-BR/Cast.php
@@ -12,6 +12,11 @@
 // Cast language settings
 return [
     'baseCastMissing'        => 'A classe "{0}" deve herdar da classe "CodeIgniter\Entity\Cast\BaseCast".', // 'The "{0}" class must inherit the "CodeIgniter\Entity\Cast\BaseCast" class.',
+    'enumInvalidCaseName'    => 'O nome do caso "{0}" é inválido para o Enum "{1}".', // 'Invalid case name "{0}" for enum "{1}".',
+    'enumInvalidType'        => 'Era esperado um Enum do tipo "{1}", mas foi recebido "{0}".', // 'Expected enum of type "{1}", but received "{0}".',
+    'enumInvalidValue'       => 'O valor "{1}" é inválido para o Enum "{0}".', // 'Invalid value "{1}" for enum "{0}".',
+    'enumMissingClass'       => 'A classe do Enum deve ser especificada para realizar o casting.', // 'Enum class must be specified for enum casting.',
+    'enumNotEnum'            => '"{0}" não é uma classe Enum válida.', // 'The "{0}" is not a valid enum class.',
     'invalidCastMethod'      => 'O método de conversão "{0}" é inválido, métodos válidos são: ["get", "set"].', // 'The "{0}" is invalid cast method, valid methods are: ["get", "set"].',
     'invalidTimestamp'       => 'Conversão do tipo "timestamp" espera um timestamp correto.', // 'Type casting "timestamp" expects a correct timestamp.',
     'jsonErrorCtrlChar'      => 'Caractere de controle inesperado encontrado.', // 'Unexpected control character found.',

--- a/Language/pt-BR/Email.php
+++ b/Language/pt-BR/Email.php
@@ -11,23 +11,26 @@
 
 // Email language settings
 return [
-    'mustBeArray'          => 'O método de validação de e-mail deve receber uma array.', // 'The email validation method must be passed an array.',
-    'invalidAddress'       => 'Endereço de e-mail inválido: "{0}"', // Invalid email address: "{0}"',
-    'attachmentMissing'    => 'Não foi possível localizar o seguinte anexo de e-mail: "{0}"', // 'Unable to locate the following email attachment: "{0}"'
-    'attachmentUnreadable' => 'Não foi possível abrir este anexo: "{0}"', // 'Unable to open this attachment: "{0}"',
-    'noFrom'               => 'Não é possível enviar e-mail sem o cabeçalho "From".', // 'Cannot send mail with no "From" header.',
-    'noRecipients'         => 'Você deve incluir destinatários: To, Cc, ou Bcc', // 'You must include recipients: To, Cc, or Bcc',
-    'sendFailurePHPMail'   => 'Não foi possível enviar e-mail usando PHP mail(). Seu servidor pode não estar configurado para enviar e-mail usando este método.', // 'Unable to send email using PHP mail(). Your server might not be configured to send mail using this method.',
-    'sendFailureSendmail'  => 'Não foi possível enviar e-mail usando PHP Sendmail. Seu servidor pode não estar configurado para enviar e-mail usando este método.', // 'Unable to send email using Sendmail. Your server might not be configured to send mail using this method.',
-    'sendFailureSmtp'      => 'Não foi possível enviar e-mail usando PHP SMTP. Seu servidor pode não estar configurado para enviar e-mail usando este método.', // 'Unable to send email using SMTP. Your server might not be configured to send mail using this method.',
-    'sent'                 => 'Sua mensagem foi enviada com sucesso usando o seguinte protocolo: "{0}"', // 'Your message has been successfully sent using the following protocol: {0}',
-    'noSocket'             => 'Não foi possível abrir um soquete para o Sendmail. Por favor, verifique as configurações.', // 'Unable to open a socket to Sendmail. Please check settings.',
-    'noHostname'           => 'Você não especificou um hostname SMTP.', // 'You did not specify a SMTP hostname.',
-    'SMTPError'            => 'O seguinte erro SMTP foi encontrado: "{0}"', // 'The following SMTP error was encountered: {0}',
-    'noSMTPAuth'           => 'Erro: você deve atribuir um nome de usuário e senha SMTP.', // 'Error: You must assign an SMTP username and password.',
-    'failedSMTPLogin'      => 'Falha ao enviar o comando AUTH LOGIN. Erro: "{0}"', // 'Failed to send AUTH LOGIN command. Error: {0}',
-    'SMTPAuthUsername'     => 'Falha ao autenticar o nome de usuário. Erro: "{0}"', // 'Failed to authenticate username. Error: {0}',
-    'SMTPAuthPassword'     => 'Falha ao autenticar a senha. Erro: "{0}"', // Failed to authenticate password. Error: {0}',
-    'SMTPDataFailure'      => 'Não foi possível enviar dados: "{0}"', // 'Unable to send data: {0}',
-    'exitStatus'           => 'Código de status de saída: "{0}"', // 'Exit status code: {0}',
+    'mustBeArray'           => 'O método de validação de e-mail deve receber uma array.', // 'The email validation method must be passed an array.',
+    'invalidAddress'        => 'Endereço de e-mail inválido: "{0}"', // Invalid email address: "{0}"',
+    'attachmentMissing'     => 'Não foi possível localizar o seguinte anexo de e-mail: "{0}"', // 'Unable to locate the following email attachment: "{0}"'
+    'attachmentUnreadable'  => 'Não foi possível abrir este anexo: "{0}"', // 'Unable to open this attachment: "{0}"',
+    'noFrom'                => 'Não é possível enviar e-mail sem o cabeçalho "From".', // 'Cannot send mail with no "From" header.',
+    'noRecipients'          => 'Você deve incluir destinatários: To, Cc, ou Bcc', // 'You must include recipients: To, Cc, or Bcc',
+    'sendFailurePHPMail'    => 'Não foi possível enviar e-mail usando PHP mail(). Seu servidor pode não estar configurado para enviar e-mail usando este método.', // 'Unable to send email using PHP mail(). Your server might not be configured to send mail using this method.',
+    'sendFailureSendmail'   => 'Não foi possível enviar e-mail usando PHP Sendmail. Seu servidor pode não estar configurado para enviar e-mail usando este método.', // 'Unable to send email using Sendmail. Your server might not be configured to send mail using this method.',
+    'sendFailureSmtp'       => 'Não foi possível enviar e-mail usando PHP SMTP. Seu servidor pode não estar configurado para enviar e-mail usando este método.', // 'Unable to send email using SMTP. Your server might not be configured to send mail using this method.',
+    'sent'                  => 'Sua mensagem foi enviada com sucesso usando o seguinte protocolo: "{0}"', // 'Your message has been successfully sent using the following protocol: {0}',
+    'noSocket'              => 'Não foi possível abrir um soquete para o Sendmail. Por favor, verifique as configurações.', // 'Unable to open a socket to Sendmail. Please check settings.',
+    'noHostname'            => 'Você não especificou um hostname SMTP.', // 'You did not specify a SMTP hostname.',
+    'SMTPError'             => 'O seguinte erro SMTP foi encontrado: "{0}"', // 'The following SMTP error was encountered: {0}',
+    'noSMTPAuth'            => 'Erro: você deve atribuir um nome de usuário e senha SMTP.', // 'Error: You must assign an SMTP username and password.',
+    'invalidSMTPAuthMethod' => 'Erro: O método de autorização SMTP "{0}" não é suportado no CodeIgniter, defina o método de autorização como "login" ou "plain"', // Error: SMTP authorization method "{0}" is not supported in codeigniter, set either "login" or "plain" authorization method
+    'failureSMTPAuthMethod' => 'Não foi possível iniciar o comando AUTH. Seu servidor pode não estar configurado para usar o método de autenticação AUTH {0}.', // Unable to initiate AUTH command. Your server might not be configured to use AUTH {0} authentication method.
+    'SMTPAuthCredentials'   => 'Falha ao autenticar as credenciais do usuário. Erro: {0}', // Failed to authenticate user credentials. Error: {0}
+    'SMTPAuthUsername'      => 'Falha ao autenticar o nome de usuário. Erro: "{0}"', // 'Failed to authenticate username. Error: {0}',
+    'SMTPAuthPassword'      => 'Falha ao autenticar a senha. Erro: "{0}"', // Failed to authenticate password. Error: {0}',
+    'SMTPDataFailure'       => 'Não foi possível enviar dados: "{0}"', // 'Unable to send data: {0}',
+    'exitStatus'            => 'Código de status de saída: "{0}"', // 'Exit status code: {0}',
+    'failedSMTPLogin'       => 'Falha ao enviar o comando AUTH LOGIN. Erro: "{0}"', // 'Failed to send AUTH LOGIN command. Error: {0}',
 ];

--- a/Language/pt-BR/Honeypot.php
+++ b/Language/pt-BR/Honeypot.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+// Honeypot language settings
+return [
+    'noTemplate'      => 'O template HTML para o Honeypot não está configurado.', // The HTML template for the Honeypot is not configured.
+    'noNameField'     => 'O nome do campo do Honeypot não está definido.', // The name of the Honeypot field is not set.
+    'theClientIsABot' => 'O cliente do Honeypot pode ser um bot.', // The Honeypot client may be a bot.
+];

--- a/Language/pt-BR/Images.php
+++ b/Language/pt-BR/Images.php
@@ -22,7 +22,6 @@ return [
     'unsupportedImageCreate' => 'Seu servidor não suporta a função GD necessária para processar este tipo de imagem.', // 'Your server does not support the GD function required to process this type of image.',
     'jpgOrPngRequired'       => 'O protocolo de redimensionamento de imagem especificado nas suas preferências só funciona com os tipos de imagem JPEG ou PNG.', // 'The image resize protocol specified in your preferences only works with JPEG or PNG image types.',
     'rotateUnsupported'      => 'A rotação de imagem não parece ser suportada pelo seu servidor.', // 'Image rotation does not appear to be supported by your server.',
-    'libPathInvalid'         => 'O caminho para a sua biblioteca de imagens não está correto. Por favor, defina o caminho correto nas suas preferências de imagem. "{0}"', // 'The path to your image library is not correct. Please set the correct path in your image preferences. "{0}"',
     'imageProcessFailed'     => 'O processamento de imagem falhou. Por favor, verifique se o seu servidor suporta o protocolo escolhido e se o caminho para a sua biblioteca de imagens está correto.', // 'Image processing failed. Please verify that your server supports the chosen protocol and that the path to your image library is correct.',
     'rotationAngleRequired'  => 'Um ângulo de rotação é necessário para girar a imagem.', // 'An angle of rotation is required to rotate the image.',
     'invalidPath'            => 'O caminho para a imagem não está correto.', // 'The path to the image is not correct.',
@@ -31,4 +30,5 @@ return [
     'saveFailed'             => 'Não é possível salvar a imagem. Por favor, certifique-se de que a imagem e o diretório de arquivos são graváveis.', // 'Unable to save the image. Please make sure the image and file directory are writable.',
     'invalidDirection'       => 'A direção da giro pode ser somente "vertical" ou "horizontal". Dado: "{0}"', // 'Flip direction can be only "vertical" or "horizontal". Given: "{0}"',
     'exifNotSupported'       => 'A leitura de dados EXIF não é suportada por esta instalação do PHP.', // 'Reading EXIF data is not supported by this PHP installation.',
+    'libPathInvalid'         => 'O caminho para a sua biblioteca de imagens não está correto. Por favor, defina o caminho correto nas suas preferências de imagem. "{0}"', // 'The path to your image library is not correct. Please set the correct path in your image preferences. "{0}"',
 ];

--- a/Language/pt-BR/Migrations.php
+++ b/Language/pt-BR/Migrations.php
@@ -20,6 +20,7 @@ return [
     'gap'           => 'Há uma diferença na sequência de migration perto do número de versão: ', // 'There is a gap in the migration sequence near version number: ',
     'classNotFound' => 'A classe migration "%s" não foi encontrada.', // 'The migration class "%s" could not be found.',
     'missingMethod' => 'A classe migration está sem um método "%s".', // 'The migration class is missing an "%s" method.',
+    'locked'        => 'Migrations já estão em execução em outro processo. Ignorando.', // Migrations already running in another process. Skipping.
 
     // Migration Command
     'migHelpLatest'   => "\t\tMigra o banco de dados para a última migration disponível.", // "\t\tMigrates database to latest available migration.",

--- a/Language/pt-BR/RESTful.php
+++ b/Language/pt-BR/RESTful.php
@@ -10,6 +10,9 @@
  */
 
 // RESTful language settings
+
 return [
-    'notImplemented' => '"{0}" ação não implementada.', // '"{0}" action not implemented.',
+    'notImplemented' => 'Ação "{0}" não implementada.', // "{0}" action not implemented.
+    'cannotPaginate' => 'Não foi possível recuperar os dados paginados.', // Unable to retrieve paginated data.
+    'paginateError'  => 'Ocorreu um erro ao paginar os resultados.', // An error occurred while paginating results.
 ];

--- a/Language/pt-BR/Validation.php
+++ b/Language/pt-BR/Validation.php
@@ -63,7 +63,7 @@ return [
     'valid_json'            => 'O campo {field} deve conter um json válido.', // 'The {field} field must contain a valid json.',
 
     // Credit Cards
-    'valid_cc_num' => '{field} não parece ser um número de cartão de crédito válido.', // '{field} does not appear to be a valid credit card number.',
+    'valid_cc_number' => '{field} não parece ser um número de cartão de crédito válido.', // {field} does not appear to be a valid credit card number.
 
     // Files
     'uploaded' => '{field} não é um arquivo de upload válido.', // '{field} is not a valid uploaded file.',


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
In this commit, I translated 100% of the files to Portuguese (Brazil) `pt-BR`, including all previously missing files and language keys. Furthermore, I fixed the array key ordering to ensure all PHPUnit tests pass successfully.
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
