### PR TITLE
[de] Update for 4.7.3

### DIFF
--- a/Language/de/Cache.php
+++ b/Language/de/Cache.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 // Cache language settings
 return [
     'unableToWrite'   => 'Cache kann nicht nach {0} geschrieben werden',
+    'invalidHandler'  => 'Der Cache-Treiber "{0}" ist kein gültiger Cache-Handler.',
     'invalidHandlers' => '$validHandlers muss ein Array zur Cache-Konfiguration enthalten.',
     'noBackup'        => 'Die Cache-Konfiguration muss über einen Handler und einen Backup-Handler verfügen.',
     'handlerNotFound' => 'In der Cache-Konfiguration ist ein ungültiger Handler oder Backup-Handler angegeben.',


### PR DESCRIPTION
[de] translation for 'Cache driver "{0}" is not a valid cache handler.'